### PR TITLE
fix: duplicate enum value

### DIFF
--- a/bm_serial.h
+++ b/bm_serial.h
@@ -89,8 +89,7 @@ typedef enum {
   BM_SERIAL_UNSUPPORTED_MSG = -7,
   BM_SERIAL_INVALID_TOPIC_LEN = -8,
   BM_SERIAL_INVALID_MSG_LEN = -9,
-
-  BM_SERIAL_MISC_ERR,
+  BM_SERIAL_MISC_ERR = -10,
 } bm_serial_error_e;
 
 void bm_serial_set_callbacks(bm_serial_callbacks_t *callbacks);


### PR DESCRIPTION
The miscellaneous error was previously set to -8 duplicating `BM_SERIAL_INVALID_TOPIC_LEN`.