### PR TITLE
Sc 195243/add bcmp info resources

### DIFF
--- a/bm_serial.c
+++ b/bm_serial.c
@@ -1008,7 +1008,7 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet, size_t le
       }
       case BM_SERIAL_RESOURCE_REPLY: {
         if(_callbacks.bcmp_resource_response_fn) {
-          bm_serial_resource_table_reply_t* resource_reply = (bm_common_network_info_t*) packet->payload;
+          bm_serial_resource_table_reply_t* resource_reply = (bm_serial_resource_table_reply_t*) packet->payload;
           _callbacks.bcmp_resource_response_fn(resource_reply->node_id, resource_reply);
         }
         break;

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -985,6 +985,34 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet, size_t le
         }
         break;
       }
+      case BM_SERIAL_DEVICE_INFO_REQ: {
+        if(_callbacks.bcmp_info_request_fn) {
+          bm_serial_device_info_request_t *info_req = (bm_serial_device_info_request_t*) packet->payload;
+          _callbacks.bcmp_info_request_fn(info_req->target_node_id);
+        }
+        break;
+      }
+      case BM_SERIAL_DEVICE_INFO_REPLY: {
+        if(_callbacks.bcmp_info_response_fn) {
+          bm_serial_device_info_reply_t* info_reply = (bm_serial_device_info_reply_t*) packet->payload;
+          _callbacks.bcmp_info_response_fn(info_reply->info.node_id, info_reply);
+        }
+        break;
+      }
+      case BM_SERIAL_RESOURCE_REQ: {
+        if(_callbacks.bcmp_resource_request_fn) {
+          bm_serial_resource_table_request_t *resource_req = (bm_serial_resource_table_request_t*) packet->payload;
+          _callbacks.bcmp_resource_request_fn(resource_req->target_node_id);
+        }
+        break;
+      }
+      case BM_SERIAL_RESOURCE_REPLY: {
+        if(_callbacks.bcmp_resource_response_fn) {
+          bm_serial_resource_table_reply_t* resource_reply = (bm_common_network_info_t*) packet->payload;
+          _callbacks.bcmp_resource_response_fn(resource_reply->node_id, resource_reply);
+        }
+        break;
+      }
       default: {
         rval = BM_SERIAL_UNSUPPORTED_MSG;
         break;

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -716,7 +716,7 @@ bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id, bm_serial_device_i
   ( void ) node_id;
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_reply_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_reply_t) + bcmp_info->dev_name_len + bcmp_info->ver_str_len;
     bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REPLY, 0, message_len);
 
     if(!packet) {
@@ -724,7 +724,7 @@ bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id, bm_serial_device_i
       break;
     }
     bm_serial_device_info_reply_t *device_info_reply_msg = (bm_serial_device_info_reply_t *)packet->payload;
-    memcpy(device_info_reply_msg, bcmp_info, sizeof(bm_serial_device_info_reply_t));
+    memcpy(device_info_reply_msg, bcmp_info, sizeof(bm_serial_device_info_reply_t)+ bcmp_info->dev_name_len + bcmp_info->ver_str_len);
     packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
     if(!_callbacks.tx_fn((uint8_t *)packet, message_len)) {
       rval = BM_SERIAL_TX_ERR;

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -717,7 +717,7 @@ bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id, bm_serial_device_i
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
     uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_reply_t);
-    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REPLY, 0, message_len);
 
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -738,7 +738,7 @@ bm_serial_error_e bm_serial_send_resource_request(uint64_t node_id){
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
     uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_request_t);
-    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_RESOURCE_REQ, 0, message_len);
 
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -760,7 +760,7 @@ bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_reso
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
     uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_request_t);
-    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_RESOURCE_REPLY, 0, message_len);
 
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -373,7 +373,7 @@ bm_serial_error_e bm_serial_send_self_test(uint64_t node_id, uint32_t result) {
   \param[in] node_id node id of device who ran self test (or 0 to request one)
   \param[in] reboot_reason reboot reason enum
   \param[in] gitSHA 32-bit gitSHA
-  \param[in] reboot_count reboot count  
+  \param[in] reboot_count reboot count
   \return BM_SERIAL_OK on successful send, nonzero otherwise
 */
 bm_serial_error_e bm_serial_send_reboot_info(uint64_t node_id, uint32_t reboot_reason, uint32_t gitSHA, uint32_t reboot_count) {
@@ -515,7 +515,7 @@ bm_serial_error_e bm_serial_cfg_set(uint64_t node_id, bm_common_config_partition
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
 
     bm_common_config_set_t *cfg_set_msg = (bm_common_config_set_t *)packet->payload;
     cfg_set_msg->header.target_node_id = node_id;
@@ -543,7 +543,7 @@ bm_serial_error_e bm_serial_cfg_value(uint64_t node_id, bm_common_config_partiti
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
 
     bm_common_config_value_t *cfg_value_msg = (bm_common_config_value_t *)packet->payload;
     cfg_value_msg->header.target_node_id = 0; // UNUSED
@@ -569,7 +569,7 @@ bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id, bm_common_config_partit
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
     bm_common_config_commit_t *cfg_commit_msg = (bm_common_config_commit_t *)packet->payload;
     cfg_commit_msg->header.target_node_id = node_id;
     cfg_commit_msg->header.source_node_id = 0; // UNUSED.
@@ -592,7 +592,7 @@ bm_serial_error_e bm_serial_cfg_status_request(uint64_t node_id, bm_common_confi
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
     bm_common_config_status_request_t* status_req_msg =  (bm_common_config_status_request_t *)packet->payload;
     status_req_msg->header.target_node_id = node_id;
     status_req_msg->header.source_node_id = 0; // UNUSED.
@@ -623,7 +623,7 @@ bm_serial_error_e bm_serial_cfg_status_response(uint64_t node_id, bm_common_conf
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
     bm_common_config_status_response_t* status_resp_msg = (bm_common_config_status_response_t*)packet->payload;
     status_resp_msg->header.target_node_id = 0; // UNUSED
     status_resp_msg->header.source_node_id = node_id; // UNUSED.
@@ -649,7 +649,7 @@ bm_serial_error_e bm_serial_cfg_delete_request(uint64_t node_id, bm_common_confi
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
     bm_common_config_delete_key_request_t* del_key_req = (bm_common_config_delete_key_request_t*) packet->payload;
     del_key_req->header.target_node_id = node_id;
     del_key_req->header.source_node_id = 0; // UNUSED.
@@ -674,7 +674,7 @@ bm_serial_error_e bm_serial_cfg_delete_response(uint64_t node_id, bm_common_conf
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
-    }    
+    }
     bm_common_config_delete_key_response_t* del_key_resp = (bm_common_config_delete_key_response_t*) packet->payload;
     del_key_resp->header.target_node_id = 0; // UNUSED
     del_key_resp->header.source_node_id = node_id;
@@ -689,6 +689,55 @@ bm_serial_error_e bm_serial_cfg_delete_response(uint64_t node_id, bm_common_conf
     }
   } while(0);
   return rval;
+}
+
+bm_serial_error_e bm_serial_send_info_request(uint64_t node_id) {
+  bm_serial_error_e rval = BM_SERIAL_OK;
+  do {
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_request_t);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
+
+    if(!packet) {
+      rval = BM_SERIAL_OUT_OF_MEMORY;
+      break;
+    }
+    bm_serial_device_info_request_t *device_info_req_msg = (bm_serial_device_info_request_t *)packet->payload;
+    device_info_req_msg->target_node_id = node_id;
+    packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
+    if(!_callbacks.tx_fn((uint8_t *)packet, message_len)) {
+      rval = BM_SERIAL_TX_ERR;
+      break;
+    }
+  } while(0);
+  return rval;
+}
+
+bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id, bm_serial_device_info_reply_t* bcmp_info) {
+
+}
+
+bm_serial_error_e bm_serial_send_resource_request(uint64_t node_id){
+  bm_serial_error_e rval = BM_SERIAL_OK;
+  do {
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_request_t);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
+
+    if(!packet) {
+      rval = BM_SERIAL_OUT_OF_MEMORY;
+      break;
+    }
+    bm_serial_resource_table_request_t *resource_req_msg = (bm_serial_resource_table_request_t *)packet->payload;
+    resource_req_msg->target_node_id = node_id;
+    packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
+    if(!_callbacks.tx_fn((uint8_t *)packet, message_len)) {
+      rval = BM_SERIAL_TX_ERR;
+      break;
+    }
+  } while(0);
+}
+
+bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_resource_table_reply_t* bcmp_resource) {
+
 }
 
 // Process bm_serial packet (not COBS anymore!)

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -794,7 +794,7 @@ bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_reso
       break;
     }
     bm_serial_resource_table_reply_t *resource_req_msg = (bm_serial_resource_table_reply_t *)packet->payload;
-    memcpy(resource_req_msg, bcmp_resource, sizeof(bm_serial_resource_table_reply_t));
+    memcpy(resource_req_msg, bcmp_resource, sizeof(bm_serial_resource_table_reply_t) + length_of_resources);
     packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
     if(!_callbacks.tx_fn((uint8_t *)packet, message_len)) {
       rval = BM_SERIAL_TX_ERR;

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -769,7 +769,7 @@ bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_reso
   ( void ) node_id;
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_request_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_reply_t);
 
     size_t length_of_resources = 0;
     uint16_t num_pubs = bcmp_resource->num_pubs;

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -775,14 +775,12 @@ bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_reso
     uint16_t num_pubs = bcmp_resource->num_pubs;
     while(num_pubs){
         bcmp_resource_t * cur_resource = (bcmp_resource_t *)(&bcmp_resource->resource_list[length_of_resources]);
-        printf("\t* %.*s\n",cur_resource->resource_len, cur_resource->resource);
         length_of_resources += (sizeof(bcmp_resource_t) + cur_resource->resource_len);
         num_pubs--;
     }
     uint16_t num_subs = bcmp_resource->num_subs;
     while(num_subs){
         bcmp_resource_t * cur_resource = (bcmp_resource_t *)(&bcmp_resource->resource_list[length_of_resources]);
-        printf("\t* %.*s\n",cur_resource->resource_len, cur_resource->resource);
         length_of_resources += (sizeof(bcmp_resource_t) + cur_resource->resource_len);
         num_subs--;
     }

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -713,17 +713,18 @@ bm_serial_error_e bm_serial_send_info_request(uint64_t node_id) {
 }
 
 bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id, bm_serial_device_info_reply_t* bcmp_info) {
+  ( void ) node_id;
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_request_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_reply_t);
     bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
 
     if(!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_serial_device_info_request_t *device_info_req_msg = (bm_serial_device_info_request_t *)packet->payload;
-    device_info_req_msg->target_node_id = node_id;
+    bm_serial_device_info_reply_t *device_info_reply_msg = (bm_serial_device_info_reply_t *)packet->payload;
+    memcpy(device_info_reply_msg, bcmp_info, sizeof(bm_serial_device_info_reply_t));
     packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
     if(!_callbacks.tx_fn((uint8_t *)packet, message_len)) {
       rval = BM_SERIAL_TX_ERR;
@@ -751,10 +752,29 @@ bm_serial_error_e bm_serial_send_resource_request(uint64_t node_id){
       break;
     }
   } while(0);
+  return rval;
 }
 
 bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_resource_table_reply_t* bcmp_resource) {
+  ( void ) node_id;
+  bm_serial_error_e rval = BM_SERIAL_OK;
+  do {
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_request_t);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
 
+    if(!packet) {
+      rval = BM_SERIAL_OUT_OF_MEMORY;
+      break;
+    }
+    bm_serial_resource_table_reply_t *resource_req_msg = (bm_serial_resource_table_reply_t *)packet->payload;
+    memcpy(resource_req_msg, bcmp_resource, sizeof(bm_serial_resource_table_reply_t));
+    packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
+    if(!_callbacks.tx_fn((uint8_t *)packet, message_len)) {
+      rval = BM_SERIAL_TX_ERR;
+      break;
+    }
+  } while(0);
+  return rval;
 }
 
 // Process bm_serial packet (not COBS anymore!)

--- a/bm_serial.h
+++ b/bm_serial.h
@@ -76,6 +76,12 @@ typedef struct {
 
   // Function called when a network info is received
   bool (*network_info_fn)(bm_common_network_info_t* network_info);
+
+  // Function called when a BCMP info request is received
+  bool (*bcmp_info_request_fn)(uint64_t node_id);
+
+  //Function called when a BCMP info response is received
+  bool (*bcmp_info_response_fn)(uint64_t node_id, bm_serial_device_info_reply_t* bcmp_info);
 } bm_serial_callbacks_t;
 
 typedef enum {
@@ -116,6 +122,12 @@ bm_serial_error_e bm_serial_cfg_status_request(uint64_t node_id, bm_common_confi
 bm_serial_error_e bm_serial_cfg_status_response(uint64_t node_id, bm_common_config_partition_e partition, bool commited, uint8_t num_keys, void* keys);
 bm_serial_error_e bm_serial_cfg_delete_request(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len, const char * key);
 bm_serial_error_e bm_serial_cfg_delete_response(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len, const char * key, bool success);
+
+bm_serial_error_e bm_serial_send_info_request(uint64_t node_id);
+bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id, bm_serial_device_info_reply_t* bcmp_info);
+
+bm_serial_error_e bm_serial_send_resource_request(uint64_t node_id);
+bm_serial_error_e bm_serial_send_resource_reply(uint64_t node_id, bm_serial_resource_table_reply_t* bcmp_resource);
 
 bm_serial_error_e bm_serial_send_network_info(uint32_t network_crc32, bm_common_config_crc_t *config_crc, bm_common_fw_version_t *fw_info, uint16_t num_nodes, uint64_t* node_id_list);
 #ifdef __cplusplus

--- a/bm_serial.h
+++ b/bm_serial.h
@@ -74,14 +74,20 @@ typedef struct {
   // Function called when a cfg del is received.
   bool (*cfg_key_del_response_fn)(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len, const char * key, bool success);
 
-  // Function called when a network info is received
+  // Function called when a network info is received.
   bool (*network_info_fn)(bm_common_network_info_t* network_info);
 
-  // Function called when a BCMP info request is received
+  // Function called when a BCMP info request is received.
   bool (*bcmp_info_request_fn)(uint64_t node_id);
 
-  //Function called when a BCMP info response is received
+  // Function called when a BCMP info response is received.
   bool (*bcmp_info_response_fn)(uint64_t node_id, bm_serial_device_info_reply_t* bcmp_info);
+
+  // Function called when a BCMP resource request is received.
+  bool (*bcmp_resource_request_fn)(uint64_t node_id);
+
+  // Function called when a BCMP resource response is received.
+  bool (*bcmp_resource_response_fn)(uint64_t node_id, bm_serial_resource_table_reply_t* bcmp_resource);
 } bm_serial_callbacks_t;
 
 typedef enum {

--- a/bm_serial_messages.h
+++ b/bm_serial_messages.h
@@ -210,7 +210,10 @@ typedef struct {
   // Number of subscribed topics
   uint16_t num_subs;
 
-  // List of structures containing information for all resource interests known about in this node.
-  // List of bcmp_resource_t structured as num_pub published resources, then num_sub, subscribed resources.
+  // List containing information for all resource interests known about this node.
+  // The list is comprised of bcmp_reosurce_t structures that are ordered such that
+  // the published resources are listed first, followed by the subscribed resources.
+  // The list can be traversed using 0 to (num_pubs - 1) to access the published resources,
+  // and num_pubs to (num_pubs + num_subs - 1) to access the subscribed resources.
   uint8_t resource_list[0];
 } __attribute__((packed)) bm_serial_resource_table_reply_t;

--- a/bm_serial_messages.h
+++ b/bm_serial_messages.h
@@ -29,6 +29,12 @@ typedef enum {
   BM_SERIAL_CFG_STATUS_RESP = 0x45,
   BM_SERIAL_CFG_DEL_REQ = 0x46,
   BM_SERIAL_CFG_DEL_RESP = 0x47,
+
+  BM_SERIAL_DEVICE_INFO_REQ = 0x50,
+  BM_SERIAL_DEVICE_INFO_REPLY = 0x51,
+  BM_SERIAL_RESOURCE_REQ = 0x52,
+  BM_SERIAL_RESOURCE_REPLY = 0x53,
+
 } bm_serial_message_t;
 
 typedef struct {
@@ -100,8 +106,8 @@ typedef struct {
   // minor version
   uint8_t minor_ver;
   // filter for update
-  uint32_t filter_key; 
-  // git hash 
+  uint32_t filter_key;
+  // git hash
   uint32_t gitSHA;
 } __attribute__ ((packed)) bm_serial_dfu_start_t;
 
@@ -125,12 +131,86 @@ typedef struct {
 } __attribute__ ((packed)) bm_serial_dfu_finish_t;
 
 typedef struct {
-  // Node id 
+  // Node id
   uint64_t node_id;
   // Reboot Reason
   uint32_t reboot_reason;
-  // git hash 
+  // git hash
   uint32_t gitSHA;
-  // reboot count 
+  // reboot count
   uint32_t reboot_count;
 } __attribute__ ((packed)) bm_serial_reboot_info_t;
+
+typedef struct {
+  // Node ID of the target node for which the request is being made. (Zeroed = all nodes)
+  uint64_t target_node_id;
+} __attribute__((packed)) bm_serial_device_info_request_t;
+
+typedef struct {
+  // Node ID of the responding node
+  uint64_t node_id;
+
+  // Vendor ID of the hardware module implementing the BM Node functions
+  uint16_t vendor_id;
+
+  // Product ID for the hardware module implementing the BM Node functions
+  uint16_t product_id;
+
+  // Factory-flashed unique serial number
+  uint8_t serial_num[16];
+
+  // Last 4 bytes of git SHA
+  uint32_t git_sha;
+
+  // Major Version
+  uint8_t ver_major;
+
+  // Minor Version
+  uint8_t ver_minor;
+
+  // Revision/Patch Version
+  uint8_t ver_rev;
+
+  // Version of the product hardware (0 for don't care)
+  uint8_t ver_hw;
+} __attribute__((packed)) bm_serial_device_info_t;
+
+typedef struct {
+  bm_serial_device_info_t info;
+
+  // Length of the full version string
+  uint8_t ver_str_len;
+
+  // Length of device name
+  uint8_t dev_name_len;
+
+  // ver_str is immediately followed by dev_name_len
+  char strings[0];
+} __attribute__((packed)) bm_serial_device_info_reply_t;
+
+typedef struct {
+  // Node ID of the target node for which the request is being made. (Zeroed = all nodes)
+  uint64_t target_node_id;
+} __attribute__((packed)) bm_serial_resource_table_request_t;
+
+typedef struct {
+  // Length of resource name
+  uint16_t resource_len;
+  // Name of resource
+  char resource[0];
+} __attribute__((packed)) bm_serial_resource_t;
+
+typedef struct {
+  // Node ID of the responding node
+  uint64_t node_id;
+
+  // Number of published topics
+  uint16_t num_pubs;
+
+  // Number of subscribed topics
+  uint16_t num_subs;
+
+  // List of structures containing information for all resource interests known about in this node.
+  // List of bcmp_resource_t structured as num_pub published resources, then num_sub, subscribed resources.
+  uint8_t resource_list[0];
+} __attribute__((packed)) bm_serial_resource_table_reply_t;

--- a/bm_serial_messages.h
+++ b/bm_serial_messages.h
@@ -211,7 +211,7 @@ typedef struct {
   uint16_t num_subs;
 
   // List containing information for all resource interests known about this node.
-  // The list is comprised of bcmp_reosurce_t structures that are ordered such that
+  // The list is comprised of bcmp_resource_t structures that are ordered such that
   // the published resources are listed first, followed by the subscribed resources.
   // The list can be traversed using 0 to (num_pubs - 1) to access the published resources,
   // and num_pubs to (num_pubs + num_subs - 1) to access the subscribed resources.


### PR DESCRIPTION
Add in support for bm_serial to pass BCMP requests and replies for info and resources. This allows for a device connected to a mote via serial to request the info and resources of any device on the Bristlemouth network.