### PR TITLE
Config abstraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Checkout submodules
         run: |
           git submodule update --init third_party/googletest
-          git submodule update --init bm_common_messages
 
       - name: Run tests
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
-[submodule "bm_common_messages"]
-	path = bm_common_messages
-	url = https://github.com/bristlemouth/bm_common_messages.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,6 @@ else()
 set(BM_SERIAL_DIR ${CMAKE_CURRENT_LIST_DIR})
 message(status "BM SERIAL DIR ${BM_SERIAL_DIR}")
 
-# Include BM Common Messages
-add_subdirectory(${BM_SERIAL_DIR}/bm_common_messages bm_common_messages)
-
 set(BM_SERIAL_FILES
     ${BM_SERIAL_DIR}/bm_serial.c
     ${BM_SERIAL_DIR}/bm_serial_crc16.c
@@ -58,6 +55,7 @@ add_library(bm_serial EXCLUDE_FROM_ALL ${BM_SERIAL_FILES})
 target_compile_options(bm_serial PRIVATE ${BM_SERIAL_COMPILER_FLAGS})
 target_compile_definitions(bm_serial PRIVATE ${BM_SERIAL_DEFINITIONS})
 target_include_directories(bm_serial PRIVATE ${BM_SERIAL_INCLUDES})
+target_link_libraries(bm_serial PUBLIC bmmessages)
 
 set(BM_SERIAL_INCLUDES ${BM_SERIAL_INCLUDES} PARENT_SCOPE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CMAKE_CXX_EXTENSIONS ON)
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   add_compile_options(
     -Wall
-    -Wextra
     -Werror
     -O0
     -g
@@ -24,12 +23,28 @@ message(STATUS "Native compiling - Building Tests")
 set(SRC_DIR ${CMAKE_SOURCE_DIR})
 set(TEST_DIR ${CMAKE_SOURCE_DIR}/test)
 
-# Include BM Common Messages
-add_subdirectory(${SRC_DIR}/bm_common_messages bm_common_messages)
+include(FetchContent)
+FetchContent_Declare(
+  bmcore
+  GIT_REPOSITORY https://github.com/bristlemouth/bm_core.git
+  GIT_TAG        main
+  GIT_SUBMODULES "third_party"
+)
+FetchContent_GetProperties(bmcore)
+if(NOT bmcore_POPULATED)
+    FetchContent_Populate(bmcore)
+endif()
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        v1.15.0
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 # Setup testing
 include(CTest)
-add_subdirectory("third_party/googletest")
 add_subdirectory("test")
 
 else()

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -1,5 +1,6 @@
 #include "bm_serial.h"
 #include "bm_serial_crc.h"
+#include "messages.h"
 #include <string.h>
 
 #define MAX_TOPIC_LEN 64
@@ -63,8 +64,7 @@ static bm_serial_error_e _bm_serial_validate_topic_and_cb(const char *topic,
   \param buff_len size of required buffer
   \return pointer to buffer if allocated successfully, NULL otherwise
 */
-static bm_serial_packet_t *_bm_serial_get_packet(bm_serial_message_t type,
-                                                 uint8_t flags,
+static bm_serial_packet_t *_bm_serial_get_packet(bm_serial_message_t type, uint8_t flags,
                                                  uint16_t buff_len) {
 
   if (buff_len <= SERIAL_BUFF_LEN) {
@@ -88,8 +88,7 @@ static bm_serial_packet_t *_bm_serial_get_packet(bm_serial_message_t type,
   \param[in] len payload length
   \return BM_SERIAL_OK if topic is valid, nonzero otherwise
 */
-bm_serial_error_e bm_serial_tx(bm_serial_message_t type, const uint8_t *payload,
-                               size_t len) {
+bm_serial_error_e bm_serial_tx(bm_serial_message_t type, const uint8_t *payload, size_t len) {
   bm_serial_error_e rval = BM_SERIAL_OK;
 
   do {
@@ -141,9 +140,8 @@ bm_serial_error_e bm_serial_tx(bm_serial_message_t type, const uint8_t *payload,
   \param data_len length of data
   \return BM_SERIAL_OK if ok, nonzero otherwise
 */
-bm_serial_error_e bm_serial_pub(uint64_t node_id, const char *topic,
-                                uint16_t topic_len, const uint8_t *data,
-                                uint16_t data_len, uint8_t type,
+bm_serial_error_e bm_serial_pub(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                const uint8_t *data, uint16_t data_len, uint8_t type,
                                 uint8_t version) {
   bm_serial_error_e rval = BM_SERIAL_OK;
 
@@ -153,18 +151,15 @@ bm_serial_error_e bm_serial_pub(uint64_t node_id, const char *topic,
       break;
     }
 
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_serial_pub_header_t) + topic_len +
-                           data_len;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_PUB, 0, message_len);
+    uint16_t message_len =
+        sizeof(bm_serial_packet_t) + sizeof(bm_serial_pub_header_t) + topic_len + data_len;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_PUB, 0, message_len);
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
 
-    bm_serial_pub_header_t *pub_header =
-        (bm_serial_pub_header_t *)packet->payload;
+    bm_serial_pub_header_t *pub_header = (bm_serial_pub_header_t *)packet->payload;
     pub_header->node_id = node_id;
     pub_header->topic_len = topic_len;
     pub_header->type = type;
@@ -198,8 +193,7 @@ bm_serial_error_e bm_serial_pub(uint64_t node_id, const char *topic,
   \param sub subscribe/unsubscribe
   \return BM_SERIAL_OK on success, nonzero otherwise
 */
-static bm_serial_error_e _bm_serial_sub_unsub(const char *topic,
-                                              uint16_t topic_len, bool sub) {
+static bm_serial_error_e _bm_serial_sub_unsub(const char *topic, uint16_t topic_len, bool sub) {
   bm_serial_error_e rval = BM_SERIAL_OK;
 
   do {
@@ -223,8 +217,7 @@ static bm_serial_error_e _bm_serial_sub_unsub(const char *topic,
       break;
     }
 
-    bm_serial_sub_unsub_header_t *sub_header =
-        (bm_serial_sub_unsub_header_t *)packet->payload;
+    bm_serial_sub_unsub_header_t *sub_header = (bm_serial_sub_unsub_header_t *)packet->payload;
     sub_header->topic_len = topic_len;
     memcpy(sub_header->topic, topic, topic_len);
 
@@ -276,8 +269,7 @@ bm_serial_error_e bm_serial_set_rtc(bm_serial_time_t *time) {
   do {
     uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_rtc_t);
 
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_RTC_SET, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_RTC_SET, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -300,7 +292,7 @@ bm_serial_error_e bm_serial_set_rtc(bm_serial_time_t *time) {
 }
 
 /*!
-  Send out a bm_common_network_info_t
+  Send out a BmNetworkInfo
 
   \param[in] *config_crc
   \param[in] *fw_info
@@ -310,44 +302,40 @@ bm_serial_error_e bm_serial_set_rtc(bm_serial_time_t *time) {
   \param[in] *cbor_config_map
   \return BM_SERIAL_OK if sent, nonzero otherwise
 */
-bm_serial_error_e bm_serial_send_network_info(
-    uint32_t network_crc32, bm_common_config_crc_t *config_crc,
-    bm_common_fw_version_t *fw_info, uint16_t num_nodes, uint64_t *node_id_list,
-    uint16_t config_map_size, uint8_t *cbor_config_map) {
+bm_serial_error_e bm_serial_send_network_info(uint32_t network_crc32,
+                                              BmConfigCrc *config_crc,
+                                              BmFwVersion *fw_info,
+                                              uint16_t num_nodes, uint64_t *node_id_list,
+                                              uint16_t config_map_size,
+                                              uint8_t *cbor_config_map) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
 
-    if (!config_crc || !fw_info || !node_id_list || num_nodes == 0 ||
-        !cbor_config_map) {
+    if (!config_crc || !fw_info || !node_id_list || num_nodes == 0 || !cbor_config_map) {
       rval = BM_SERIAL_MISC_ERR;
       break;
     }
 
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_common_network_info_t) +
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(BmNetworkInfo) +
                            (sizeof(uint64_t) * num_nodes) + config_map_size;
 
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_NETWORK_INFO, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_NETWORK_INFO, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
 
-    bm_common_network_info_t *network_info =
-        (bm_common_network_info_t *)packet->payload;
+    BmNetworkInfo *network_info = (BmNetworkInfo *)packet->payload;
     network_info->network_crc32 = network_crc32;
-    memcpy(&network_info->config_crc, config_crc,
-           sizeof(bm_common_config_crc_t));
-    memcpy(&network_info->fw_info, fw_info, sizeof(bm_common_fw_version_t));
+    memcpy(&network_info->config_crc, config_crc, sizeof(BmConfigCrc));
+    memcpy(&network_info->fw_info, fw_info, sizeof(BmFwVersion));
     network_info->num_nodes = num_nodes;
     size_t node_list_size = sizeof(uint64_t) * num_nodes;
-    memcpy(&network_info->node_list_and_cbor_config_map, node_id_list,
-           node_list_size);
+    memcpy(&network_info->node_list_and_cbor_config_map, node_id_list, node_list_size);
     network_info->map_size_bytes = config_map_size;
-    memcpy(&network_info->node_list_and_cbor_config_map[node_list_size],
-           cbor_config_map, config_map_size);
+    memcpy(&network_info->node_list_and_cbor_config_map[node_list_size], cbor_config_map,
+           config_map_size);
 
     packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
 
@@ -371,11 +359,9 @@ bm_serial_error_e bm_serial_send_self_test(uint64_t node_id, uint32_t result) {
   bm_serial_error_e rval = BM_SERIAL_OK;
 
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_serial_self_test_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_self_test_t);
 
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_SELF_TEST, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_SELF_TEST, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -407,26 +393,20 @@ bm_serial_error_e bm_serial_send_self_test(uint64_t node_id, uint32_t result) {
   \param[in] reboot_count reboot count
   \return BM_SERIAL_OK on successful send, nonzero otherwise
 */
-bm_serial_error_e bm_serial_send_reboot_info(uint64_t node_id,
-                                             uint32_t reboot_reason,
-                                             uint32_t gitSHA,
-                                             uint32_t reboot_count,
-                                             uint32_t pc,
-                                             uint32_t lr) {
+bm_serial_error_e bm_serial_send_reboot_info(uint64_t node_id, uint32_t reboot_reason,
+                                             uint32_t gitSHA, uint32_t reboot_count,
+                                             uint32_t pc, uint32_t lr) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_serial_reboot_info_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_reboot_info_t);
 
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_REBOOT_INFO, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_REBOOT_INFO, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_serial_reboot_info_t *reboot_info =
-        (bm_serial_reboot_info_t *)packet->payload;
+    bm_serial_reboot_info_t *reboot_info = (bm_serial_reboot_info_t *)packet->payload;
     reboot_info->node_id = node_id;
     reboot_info->reboot_reason = reboot_reason;
     reboot_info->gitSHA = gitSHA;
@@ -445,10 +425,8 @@ bm_serial_error_e bm_serial_send_reboot_info(uint64_t node_id,
 bm_serial_error_e bm_serial_dfu_send_start(bm_serial_dfu_start_t *dfu_start) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_serial_dfu_start_t);
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_DFU_START, 0, message_len);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_dfu_start_t);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DFU_START, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -468,15 +446,12 @@ bm_serial_error_e bm_serial_dfu_send_start(bm_serial_dfu_start_t *dfu_start) {
   return rval;
 }
 
-bm_serial_error_e bm_serial_dfu_send_chunk(uint32_t offset, size_t length,
-                                           uint8_t *data) {
+bm_serial_error_e bm_serial_dfu_send_chunk(uint32_t offset, size_t length, uint8_t *data) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
 
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_serial_dfu_chunk_t) + length;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_DFU_CHUNK, 0, message_len);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_dfu_chunk_t) + length;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DFU_CHUNK, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -498,22 +473,18 @@ bm_serial_error_e bm_serial_dfu_send_chunk(uint32_t offset, size_t length,
   return rval;
 }
 
-bm_serial_error_e bm_serial_dfu_send_finish(uint64_t node_id, bool success,
-                                            uint32_t status) {
+bm_serial_error_e bm_serial_dfu_send_finish(uint64_t node_id, bool success, uint32_t status) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_serial_dfu_finish_t);
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_DFU_RESULT, 0, message_len);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_dfu_finish_t);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_DFU_RESULT, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
 
-    bm_serial_dfu_finish_t *dfu_finish =
-        (bm_serial_dfu_finish_t *)packet->payload;
+    bm_serial_dfu_finish_t *dfu_finish = (bm_serial_dfu_finish_t *)packet->payload;
     dfu_finish->dfu_status = status;
     dfu_finish->node_id = node_id;
     dfu_finish->success = success;
@@ -527,23 +498,19 @@ bm_serial_error_e bm_serial_dfu_send_finish(uint64_t node_id, bool success,
   return rval;
 }
 
-bm_serial_error_e bm_serial_cfg_get(uint64_t node_id,
-                                    BmConfigPartition partition,
+bm_serial_error_e bm_serial_cfg_get(uint64_t node_id, BmConfigPartition partition,
                                     size_t key_len, const char *key) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_common_config_get_t) + key_len;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_CFG_GET, 0, message_len);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(BmConfigGet) + key_len;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_CFG_GET, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
 
-    bm_common_config_get_t *cfg_get_msg =
-        (bm_common_config_get_t *)packet->payload;
+    BmConfigGet *cfg_get_msg = (BmConfigGet *)packet->payload;
     cfg_get_msg->header.target_node_id = node_id;
     cfg_get_msg->header.source_node_id = 0; // UNUSED
     cfg_get_msg->partition = partition;
@@ -558,25 +525,21 @@ bm_serial_error_e bm_serial_cfg_get(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e bm_serial_cfg_set(uint64_t node_id,
-                                    BmConfigPartition partition,
-                                    size_t key_len, const char *key,
-                                    size_t value_size, void *val) {
+bm_serial_error_e bm_serial_cfg_set(uint64_t node_id, BmConfigPartition partition,
+                                    size_t key_len, const char *key, size_t value_size,
+                                    void *val) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_common_config_set_t) + key_len +
-                           value_size;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_CFG_SET, 0, message_len);
+    uint16_t message_len =
+        sizeof(bm_serial_packet_t) + sizeof(BmConfigSet) + key_len + value_size;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_CFG_SET, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
 
-    bm_common_config_set_t *cfg_set_msg =
-        (bm_common_config_set_t *)packet->payload;
+    BmConfigSet *cfg_set_msg = (BmConfigSet *)packet->payload;
     cfg_set_msg->header.target_node_id = node_id;
     cfg_set_msg->header.source_node_id = 0; // UNUSED
     cfg_set_msg->partition = partition;
@@ -593,23 +556,19 @@ bm_serial_error_e bm_serial_cfg_set(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e bm_serial_cfg_value(uint64_t node_id,
-                                      BmConfigPartition partition,
+bm_serial_error_e bm_serial_cfg_value(uint64_t node_id, BmConfigPartition partition,
                                       uint32_t data_length, void *data) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_common_config_value_t) + data_length;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_CFG_VALUE, 0, message_len);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(BmConfigValue) + data_length;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_CFG_VALUE, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
 
-    bm_common_config_value_t *cfg_value_msg =
-        (bm_common_config_value_t *)packet->payload;
+    BmConfigValue *cfg_value_msg = (BmConfigValue *)packet->payload;
     cfg_value_msg->header.target_node_id = 0; // UNUSED
     cfg_value_msg->header.source_node_id = node_id;
     cfg_value_msg->partition = partition;
@@ -624,21 +583,17 @@ bm_serial_error_e bm_serial_cfg_value(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id,
-                                       BmConfigPartition partition) {
+bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id, BmConfigPartition partition) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_common_config_commit_t);
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_CFG_COMMIT, 0, message_len);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(BmConfigCommit);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_CFG_COMMIT, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_common_config_commit_t *cfg_commit_msg =
-        (bm_common_config_commit_t *)packet->payload;
+    BmConfigCommit *cfg_commit_msg = (BmConfigCommit *)packet->payload;
     cfg_commit_msg->header.target_node_id = node_id;
     cfg_commit_msg->header.source_node_id = 0; // UNUSED.
     cfg_commit_msg->partition = partition;
@@ -651,13 +606,10 @@ bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e
-bm_serial_cfg_status_request(uint64_t node_id,
-                             BmConfigPartition partition) {
+bm_serial_error_e bm_serial_cfg_status_request(uint64_t node_id, BmConfigPartition partition) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_common_config_status_request_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(BmConfigStatusRequest);
     bm_serial_packet_t *packet =
         _bm_serial_get_packet(BM_SERIAL_CFG_STATUS_REQ, 0, message_len);
 
@@ -665,8 +617,7 @@ bm_serial_cfg_status_request(uint64_t node_id,
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_common_config_status_request_t *status_req_msg =
-        (bm_common_config_status_request_t *)packet->payload;
+    BmConfigStatusRequest *status_req_msg = (BmConfigStatusRequest *)packet->payload;
     status_req_msg->header.target_node_id = node_id;
     status_req_msg->header.source_node_id = 0; // UNUSED.
     status_req_msg->partition = partition;
@@ -679,22 +630,17 @@ bm_serial_cfg_status_request(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e
-bm_serial_cfg_status_response(uint64_t node_id,
-                              BmConfigPartition partition,
-                              bool commited, uint8_t num_keys, void *keys) {
+bm_serial_error_e bm_serial_cfg_status_response(uint64_t node_id, BmConfigPartition partition,
+                                                bool commited, uint8_t num_keys, void *keys) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_common_config_status_response_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(BmConfigStatusResponse);
     size_t key_data_len = 0;
-    bm_common_config_status_key_data_t *cur_key =
-        (bm_common_config_status_key_data_t *)keys;
+    BmConfigStatusKeyData *cur_key = (BmConfigStatusKeyData *)keys;
     for (int i = 0; i < num_keys; i++) {
-      key_data_len += sizeof(bm_common_config_status_key_data_t);
+      key_data_len += sizeof(BmConfigStatusKeyData);
       key_data_len += cur_key->key_length;
-      cur_key +=
-          sizeof(bm_common_config_status_key_data_t) + cur_key->key_length;
+      cur_key += sizeof(BmConfigStatusKeyData) + cur_key->key_length;
     }
     message_len += key_data_len;
     bm_serial_packet_t *packet =
@@ -704,8 +650,7 @@ bm_serial_cfg_status_response(uint64_t node_id,
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_common_config_status_response_t *status_resp_msg =
-        (bm_common_config_status_response_t *)packet->payload;
+    BmConfigStatusResponse *status_resp_msg = (BmConfigStatusResponse *)packet->payload;
     status_resp_msg->header.target_node_id = 0;       // UNUSED
     status_resp_msg->header.source_node_id = node_id; // UNUSED.
     status_resp_msg->partition = partition;
@@ -721,24 +666,19 @@ bm_serial_cfg_status_response(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e
-bm_serial_cfg_delete_request(uint64_t node_id,
-                             BmConfigPartition partition,
-                             size_t key_len, const char *key) {
+bm_serial_error_e bm_serial_cfg_delete_request(uint64_t node_id, BmConfigPartition partition,
+                                               size_t key_len, const char *key) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_common_config_delete_key_request_t) +
-                           key_len;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_CFG_DEL_REQ, 0, message_len);
+    uint16_t message_len =
+        sizeof(bm_serial_packet_t) + sizeof(BmConfigDeleteKeyRequest) + key_len;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_CFG_DEL_REQ, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_common_config_delete_key_request_t *del_key_req =
-        (bm_common_config_delete_key_request_t *)packet->payload;
+    BmConfigDeleteKeyRequest *del_key_req = (BmConfigDeleteKeyRequest *)packet->payload;
     del_key_req->header.target_node_id = node_id;
     del_key_req->header.source_node_id = 0; // UNUSED.
     del_key_req->partition = partition;
@@ -753,24 +693,19 @@ bm_serial_cfg_delete_request(uint64_t node_id,
   return rval;
 }
 
-bm_serial_error_e
-bm_serial_cfg_delete_response(uint64_t node_id,
-                              BmConfigPartition partition,
-                              size_t key_len, const char *key, bool success) {
+bm_serial_error_e bm_serial_cfg_delete_response(uint64_t node_id, BmConfigPartition partition,
+                                                size_t key_len, const char *key, bool success) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_common_config_delete_key_response_t) +
-                           key_len;
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_CFG_DEL_RESP, 0, message_len);
+    uint16_t message_len =
+        sizeof(bm_serial_packet_t) + sizeof(BmConfigDeleteKeyResponse) + key_len;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_CFG_DEL_RESP, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
       break;
     }
-    bm_common_config_delete_key_response_t *del_key_resp =
-        (bm_common_config_delete_key_response_t *)packet->payload;
+    BmConfigDeleteKeyResponse *del_key_resp = (BmConfigDeleteKeyResponse *)packet->payload;
     del_key_resp->header.target_node_id = 0; // UNUSED
     del_key_resp->header.source_node_id = node_id;
     del_key_resp->partition = partition;
@@ -789,8 +724,7 @@ bm_serial_cfg_delete_response(uint64_t node_id,
 bm_serial_error_e bm_serial_send_info_request(uint64_t node_id) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len =
-        sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_request_t);
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_request_t);
     bm_serial_packet_t *packet =
         _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REQ, 0, message_len);
 
@@ -810,14 +744,12 @@ bm_serial_error_e bm_serial_send_info_request(uint64_t node_id) {
   return rval;
 }
 
-bm_serial_error_e
-bm_serial_send_info_reply(uint64_t node_id,
-                          bm_serial_device_info_reply_t *bcmp_info) {
+bm_serial_error_e bm_serial_send_info_reply(uint64_t node_id,
+                                            bm_serial_device_info_reply_t *bcmp_info) {
   (void)node_id;
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) +
-                           sizeof(bm_serial_device_info_reply_t) +
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_device_info_reply_t) +
                            bcmp_info->dev_name_len + bcmp_info->ver_str_len;
     bm_serial_packet_t *packet =
         _bm_serial_get_packet(BM_SERIAL_DEVICE_INFO_REPLY, 0, message_len);
@@ -845,8 +777,7 @@ bm_serial_error_e bm_serial_send_resource_request(uint64_t node_id) {
   do {
     uint16_t message_len =
         sizeof(bm_serial_packet_t) + sizeof(bm_serial_resource_table_request_t);
-    bm_serial_packet_t *packet =
-        _bm_serial_get_packet(BM_SERIAL_RESOURCE_REQ, 0, message_len);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_RESOURCE_REQ, 0, message_len);
 
     if (!packet) {
       rval = BM_SERIAL_OUT_OF_MEMORY;
@@ -888,19 +819,15 @@ bm_serial_send_resource_reply(uint64_t node_id,
     uint16_t num_pubs = bcmp_resource->num_pubs;
     while (num_pubs) {
       bcmp_resource_t *cur_resource =
-          (bcmp_resource_t *)(&bcmp_resource
-                                   ->resource_list[length_of_resources]);
-      length_of_resources +=
-          (sizeof(bcmp_resource_t) + cur_resource->resource_len);
+          (bcmp_resource_t *)(&bcmp_resource->resource_list[length_of_resources]);
+      length_of_resources += (sizeof(bcmp_resource_t) + cur_resource->resource_len);
       num_pubs--;
     }
     uint16_t num_subs = bcmp_resource->num_subs;
     while (num_subs) {
       bcmp_resource_t *cur_resource =
-          (bcmp_resource_t *)(&bcmp_resource
-                                   ->resource_list[length_of_resources]);
-      length_of_resources +=
-          (sizeof(bcmp_resource_t) + cur_resource->resource_len);
+          (bcmp_resource_t *)(&bcmp_resource->resource_list[length_of_resources]);
+      length_of_resources += (sizeof(bcmp_resource_t) + cur_resource->resource_len);
       num_subs--;
     }
 
@@ -927,8 +854,7 @@ bm_serial_send_resource_reply(uint64_t node_id,
 }
 
 // Process bm_serial packet (not COBS anymore!)
-bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
-                                           size_t len) {
+bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet, size_t len) {
   bm_serial_error_e rval = BM_SERIAL_OK;
 
   // calc the crc16 and compare
@@ -955,15 +881,13 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
         break;
       }
 
-      bm_serial_pub_header_t *pub_header =
-          (bm_serial_pub_header_t *)packet->payload;
+      bm_serial_pub_header_t *pub_header = (bm_serial_pub_header_t *)packet->payload;
 
       // Protect against topic length being incorrect
       // (would result in overflow when subtracting from len to determine data
       // len)
-      uint32_t non_data_len = sizeof(bm_serial_packet_t) +
-                              sizeof(bm_serial_pub_header_t) +
-                              pub_header->topic_len;
+      uint32_t non_data_len =
+          sizeof(bm_serial_packet_t) + sizeof(bm_serial_pub_header_t) + pub_header->topic_len;
       if (non_data_len > len) {
         rval = BM_SERIAL_INVALID_TOPIC_LEN;
         break;
@@ -971,9 +895,8 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
 
       uint32_t data_len = len - non_data_len;
       _callbacks.pub_fn((const char *)pub_header->topic, pub_header->topic_len,
-                        pub_header->node_id,
-                        &pub_header->topic[pub_header->topic_len], data_len,
-                        pub_header->type, pub_header->version);
+                        pub_header->node_id, &pub_header->topic[pub_header->topic_len],
+                        data_len, pub_header->type, pub_header->version);
 
       break;
     }
@@ -997,8 +920,7 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
 
       bm_serial_sub_unsub_header_t *unsub_header =
           (bm_serial_sub_unsub_header_t *)packet->payload;
-      _callbacks.unsub_fn((const char *)unsub_header->topic,
-                          unsub_header->topic_len);
+      _callbacks.unsub_fn((const char *)unsub_header->topic, unsub_header->topic_len);
 
       break;
     }
@@ -1013,14 +935,12 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
 
     case BM_SERIAL_NET_MSG: {
       if (_callbacks.net_msg_fn) {
-        uint32_t non_data_len =
-            sizeof(bm_serial_packet_t) + sizeof(bm_serial_net_msg_header_t);
+        uint32_t non_data_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_net_msg_header_t);
         if (non_data_len > len) {
           rval = BM_SERIAL_INVALID_MSG_LEN;
           break;
         }
-        bm_serial_net_msg_header_t *net_msg =
-            (bm_serial_net_msg_header_t *)packet->payload;
+        bm_serial_net_msg_header_t *net_msg = (bm_serial_net_msg_header_t *)packet->payload;
 
         uint32_t data_len = len - non_data_len;
         _callbacks.net_msg_fn(net_msg->node_id, net_msg->data, data_len);
@@ -1038,8 +958,7 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
 
     case BM_SERIAL_SELF_TEST: {
       if (_callbacks.self_test_fn) {
-        bm_serial_self_test_t *self_test =
-            (bm_serial_self_test_t *)packet->payload;
+        bm_serial_self_test_t *self_test = (bm_serial_self_test_t *)packet->payload;
         _callbacks.self_test_fn(self_test->node_id, self_test->result);
       }
       break;
@@ -1047,20 +966,17 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
 
     case BM_SERIAL_REBOOT_INFO: {
       if (_callbacks.reboot_info_fn) {
-        bm_serial_reboot_info_t *reboot_info =
-            (bm_serial_reboot_info_t *)packet->payload;
-        _callbacks.reboot_info_fn(
-            reboot_info->node_id, reboot_info->reboot_reason,
-            reboot_info->gitSHA, reboot_info->reboot_count,
-            reboot_info->pc, reboot_info->lr);
+        bm_serial_reboot_info_t *reboot_info = (bm_serial_reboot_info_t *)packet->payload;
+        _callbacks.reboot_info_fn(reboot_info->node_id, reboot_info->reboot_reason,
+                                  reboot_info->gitSHA, reboot_info->reboot_count,
+                                  reboot_info->pc, reboot_info->lr);
       }
       break;
     }
 
     case BM_SERIAL_DFU_START: {
       if (_callbacks.dfu_start_fn) {
-        bm_serial_dfu_start_t *dfu_start =
-            (bm_serial_dfu_start_t *)packet->payload;
+        bm_serial_dfu_start_t *dfu_start = (bm_serial_dfu_start_t *)packet->payload;
         _callbacks.dfu_start_fn(dfu_start);
       }
       break;
@@ -1068,68 +984,55 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
 
     case BM_SERIAL_DFU_CHUNK: {
       if (_callbacks.dfu_chunk_fn) {
-        bm_serial_dfu_chunk_t *dfu_chunk =
-            (bm_serial_dfu_chunk_t *)packet->payload;
-        _callbacks.dfu_chunk_fn(dfu_chunk->offset, dfu_chunk->length,
-                                dfu_chunk->data);
+        bm_serial_dfu_chunk_t *dfu_chunk = (bm_serial_dfu_chunk_t *)packet->payload;
+        _callbacks.dfu_chunk_fn(dfu_chunk->offset, dfu_chunk->length, dfu_chunk->data);
       }
       break;
     }
 
     case BM_SERIAL_DFU_RESULT: {
       if (_callbacks.dfu_end_fn) {
-        bm_serial_dfu_finish_t *dfu_end =
-            (bm_serial_dfu_finish_t *)packet->payload;
-        _callbacks.dfu_end_fn(dfu_end->node_id, dfu_end->success,
-                              dfu_end->dfu_status);
+        bm_serial_dfu_finish_t *dfu_end = (bm_serial_dfu_finish_t *)packet->payload;
+        _callbacks.dfu_end_fn(dfu_end->node_id, dfu_end->success, dfu_end->dfu_status);
       }
       break;
     }
 
     case BM_SERIAL_CFG_GET: {
       if (_callbacks.cfg_get_fn) {
-        bm_common_config_get_t *cfg_get =
-            (bm_common_config_get_t *)packet->payload;
-        _callbacks.cfg_get_fn(cfg_get->header.target_node_id,
-                              cfg_get->partition, cfg_get->key_length,
-                              cfg_get->key);
+        BmConfigGet *cfg_get = (BmConfigGet *)packet->payload;
+        _callbacks.cfg_get_fn(cfg_get->header.target_node_id, cfg_get->partition,
+                              cfg_get->key_length, cfg_get->key);
       }
       break;
     }
     case BM_SERIAL_CFG_SET: {
       if (_callbacks.cfg_set_fn) {
-        bm_common_config_set_t *cfg_set =
-            (bm_common_config_set_t *)packet->payload;
-        _callbacks.cfg_set_fn(cfg_set->header.target_node_id,
-                              cfg_set->partition, cfg_set->key_length,
-                              (char *)cfg_set->keyAndData, cfg_set->data_length,
-                              &cfg_set->keyAndData[cfg_set->key_length]);
+        BmConfigSet *cfg_set = (BmConfigSet *)packet->payload;
+        _callbacks.cfg_set_fn(cfg_set->header.target_node_id, cfg_set->partition,
+                              cfg_set->key_length, (char *)cfg_set->keyAndData,
+                              cfg_set->data_length, &cfg_set->keyAndData[cfg_set->key_length]);
       }
       break;
     }
     case BM_SERIAL_CFG_VALUE: {
       if (_callbacks.cfg_value_fn) {
-        bm_common_config_value_t *cfg_value =
-            (bm_common_config_value_t *)packet->payload;
-        _callbacks.cfg_value_fn(cfg_value->header.source_node_id,
-                                cfg_value->partition, cfg_value->data_length,
-                                cfg_value->data);
+        BmConfigValue *cfg_value = (BmConfigValue *)packet->payload;
+        _callbacks.cfg_value_fn(cfg_value->header.source_node_id, cfg_value->partition,
+                                cfg_value->data_length, cfg_value->data);
       }
       break;
     }
     case BM_SERIAL_CFG_COMMIT: {
       if (_callbacks.cfg_commit_fn) {
-        bm_common_config_commit_t *cfg_commit =
-            (bm_common_config_commit_t *)packet->payload;
-        _callbacks.cfg_commit_fn(cfg_commit->header.target_node_id,
-                                 cfg_commit->partition);
+        BmConfigCommit *cfg_commit = (BmConfigCommit *)packet->payload;
+        _callbacks.cfg_commit_fn(cfg_commit->header.target_node_id, cfg_commit->partition);
       }
       break;
     }
     case BM_SERIAL_CFG_STATUS_REQ: {
       if (_callbacks.cfg_status_request_fn) {
-        bm_common_config_status_request_t *cfg_status_req =
-            (bm_common_config_status_request_t *)packet->payload;
+        BmConfigStatusRequest *cfg_status_req = (BmConfigStatusRequest *)packet->payload;
         _callbacks.cfg_status_request_fn(cfg_status_req->header.target_node_id,
                                          cfg_status_req->partition);
       }
@@ -1137,39 +1040,34 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
     }
     case BM_SERIAL_CFG_STATUS_RESP: {
       if (_callbacks.cfg_status_response_fn) {
-        bm_common_config_status_response_t *cfg_status_resp =
-            (bm_common_config_status_response_t *)packet->payload;
+        BmConfigStatusResponse *cfg_status_resp = (BmConfigStatusResponse *)packet->payload;
         _callbacks.cfg_status_response_fn(
             cfg_status_resp->header.source_node_id, cfg_status_resp->partition,
-            cfg_status_resp->committed, cfg_status_resp->num_keys,
-            cfg_status_resp->keyData);
+            cfg_status_resp->committed, cfg_status_resp->num_keys, cfg_status_resp->keyData);
       }
       break;
     }
     case BM_SERIAL_CFG_DEL_REQ: {
       if (_callbacks.cfg_key_del_request_fn) {
-        bm_common_config_delete_key_request_t *cfg_del_req =
-            (bm_common_config_delete_key_request_t *)packet->payload;
-        _callbacks.cfg_key_del_request_fn(
-            cfg_del_req->header.target_node_id, cfg_del_req->partition,
-            cfg_del_req->key_length, cfg_del_req->key);
+        BmConfigDeleteKeyRequest *cfg_del_req = (BmConfigDeleteKeyRequest *)packet->payload;
+        _callbacks.cfg_key_del_request_fn(cfg_del_req->header.target_node_id,
+                                          cfg_del_req->partition, cfg_del_req->key_length,
+                                          cfg_del_req->key);
       }
       break;
     }
     case BM_SERIAL_CFG_DEL_RESP: {
       if (_callbacks.cfg_key_del_response_fn) {
-        bm_common_config_delete_key_response_t *cfg_del_resp =
-            (bm_common_config_delete_key_response_t *)packet->payload;
-        _callbacks.cfg_key_del_response_fn(
-            cfg_del_resp->header.source_node_id, cfg_del_resp->partition,
-            cfg_del_resp->key_length, cfg_del_resp->key, cfg_del_resp->success);
+        BmConfigDeleteKeyResponse *cfg_del_resp = (BmConfigDeleteKeyResponse *)packet->payload;
+        _callbacks.cfg_key_del_response_fn(cfg_del_resp->header.source_node_id,
+                                           cfg_del_resp->partition, cfg_del_resp->key_length,
+                                           cfg_del_resp->key, cfg_del_resp->success);
       }
       break;
     }
     case BM_SERIAL_NETWORK_INFO: {
       if (_callbacks.network_info_fn) {
-        bm_common_network_info_t *network_info =
-            (bm_common_network_info_t *)packet->payload;
+        BmNetworkInfo *network_info = (BmNetworkInfo *)packet->payload;
         _callbacks.network_info_fn(network_info);
       }
       break;
@@ -1202,8 +1100,7 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet,
       if (_callbacks.bcmp_resource_response_fn) {
         bm_serial_resource_table_reply_t *resource_reply =
             (bm_serial_resource_table_reply_t *)packet->payload;
-        _callbacks.bcmp_resource_response_fn(resource_reply->node_id,
-                                             resource_reply);
+        _callbacks.bcmp_resource_response_fn(resource_reply->node_id, resource_reply);
       }
       break;
     }

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -528,7 +528,7 @@ bm_serial_error_e bm_serial_dfu_send_finish(uint64_t node_id, bool success,
 }
 
 bm_serial_error_e bm_serial_cfg_get(uint64_t node_id,
-                                    bm_common_config_partition_e partition,
+                                    BmConfigPartition partition,
                                     size_t key_len, const char *key) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
@@ -559,7 +559,7 @@ bm_serial_error_e bm_serial_cfg_get(uint64_t node_id,
 }
 
 bm_serial_error_e bm_serial_cfg_set(uint64_t node_id,
-                                    bm_common_config_partition_e partition,
+                                    BmConfigPartition partition,
                                     size_t key_len, const char *key,
                                     size_t value_size, void *val) {
   bm_serial_error_e rval = BM_SERIAL_OK;
@@ -594,7 +594,7 @@ bm_serial_error_e bm_serial_cfg_set(uint64_t node_id,
 }
 
 bm_serial_error_e bm_serial_cfg_value(uint64_t node_id,
-                                      bm_common_config_partition_e partition,
+                                      BmConfigPartition partition,
                                       uint32_t data_length, void *data) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
@@ -625,7 +625,7 @@ bm_serial_error_e bm_serial_cfg_value(uint64_t node_id,
 }
 
 bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id,
-                                       bm_common_config_partition_e partition) {
+                                       BmConfigPartition partition) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
     uint16_t message_len =
@@ -653,7 +653,7 @@ bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id,
 
 bm_serial_error_e
 bm_serial_cfg_status_request(uint64_t node_id,
-                             bm_common_config_partition_e partition) {
+                             BmConfigPartition partition) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
     uint16_t message_len =
@@ -681,7 +681,7 @@ bm_serial_cfg_status_request(uint64_t node_id,
 
 bm_serial_error_e
 bm_serial_cfg_status_response(uint64_t node_id,
-                              bm_common_config_partition_e partition,
+                              BmConfigPartition partition,
                               bool commited, uint8_t num_keys, void *keys) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
@@ -723,7 +723,7 @@ bm_serial_cfg_status_response(uint64_t node_id,
 
 bm_serial_error_e
 bm_serial_cfg_delete_request(uint64_t node_id,
-                             bm_common_config_partition_e partition,
+                             BmConfigPartition partition,
                              size_t key_len, const char *key) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {
@@ -755,7 +755,7 @@ bm_serial_cfg_delete_request(uint64_t node_id,
 
 bm_serial_error_e
 bm_serial_cfg_delete_response(uint64_t node_id,
-                              bm_common_config_partition_e partition,
+                              BmConfigPartition partition,
                               size_t key_len, const char *key, bool success) {
   bm_serial_error_e rval = BM_SERIAL_OK;
   do {

--- a/bm_serial.h
+++ b/bm_serial.h
@@ -83,7 +83,7 @@ typedef struct {
                                   const char *key, bool success);
 
   // Function called when a network info is received.
-  bool (*network_info_fn)(bm_common_network_info_t *network_info);
+  bool (*network_info_fn)(BmNetworkInfo *network_info);
 
   // Function called when a BCMP info request is received.
   bool (*bcmp_info_request_fn)(uint64_t node_id);
@@ -158,8 +158,8 @@ bm_serial_send_resource_reply(uint64_t node_id,
                               bm_serial_resource_table_reply_t *bcmp_resource);
 
 bm_serial_error_e bm_serial_send_network_info(uint32_t network_crc32,
-                                              bm_common_config_crc_t *config_crc,
-                                              bm_common_fw_version_t *fw_info,
+                                              BmConfigCrc *config_crc,
+                                              BmFwVersion *fw_info,
                                               uint16_t num_nodes, uint64_t *node_id_list,
                                               uint16_t config_map_size,
                                               uint8_t *cbor_config_map);

--- a/bm_serial.h
+++ b/bm_serial.h
@@ -2,6 +2,7 @@
 
 #include "bm_common_structs.h"
 #include "bm_serial_messages.h"
+#include "configuration.h"
 #include <stdint.h>
 #include <stdio.h>
 
@@ -52,34 +53,34 @@ typedef struct {
   bool (*dfu_end_fn)(uint64_t node_id, bool success, uint32_t err);
 
   // Function called when a cfg get is received.
-  bool (*cfg_get_fn)(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len,
+  bool (*cfg_get_fn)(uint64_t node_id, BmConfigPartition partition, size_t key_len,
                      const char *key);
 
   // Function called when a cfg set is received.
-  bool (*cfg_set_fn)(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len,
+  bool (*cfg_set_fn)(uint64_t node_id, BmConfigPartition partition, size_t key_len,
                      const char *key, size_t value_size, void *val);
 
   // Function called when a cfg value is recieved.
-  bool (*cfg_value_fn)(uint64_t node_id, bm_common_config_partition_e partition,
-                       uint32_t data_length, void *data);
+  bool (*cfg_value_fn)(uint64_t node_id, BmConfigPartition partition, uint32_t data_length,
+                       void *data);
 
   // Function called when a cfg commit is received.
-  bool (*cfg_commit_fn)(uint64_t node_id, bm_common_config_partition_e partition);
+  bool (*cfg_commit_fn)(uint64_t node_id, BmConfigPartition partition);
 
   // Function called when a cfg status request is received.
-  bool (*cfg_status_request_fn)(uint64_t node_id, bm_common_config_partition_e partition);
+  bool (*cfg_status_request_fn)(uint64_t node_id, BmConfigPartition partition);
 
   // Function called when a cfg status response is received.
-  bool (*cfg_status_response_fn)(uint64_t node_id, bm_common_config_partition_e partition,
-                                 bool commited, uint8_t num_keys, void *keys);
+  bool (*cfg_status_response_fn)(uint64_t node_id, BmConfigPartition partition, bool commited,
+                                 uint8_t num_keys, void *keys);
 
   // Function called when a cfg del is received.
-  bool (*cfg_key_del_request_fn)(uint64_t node_id, bm_common_config_partition_e partition,
-                                 size_t key_len, const char *key);
+  bool (*cfg_key_del_request_fn)(uint64_t node_id, BmConfigPartition partition, size_t key_len,
+                                 const char *key);
 
   // Function called when a cfg del is received.
-  bool (*cfg_key_del_response_fn)(uint64_t node_id, bm_common_config_partition_e partition,
-                                  size_t key_len, const char *key, bool success);
+  bool (*cfg_key_del_response_fn)(uint64_t node_id, BmConfigPartition partition, size_t key_len,
+                                  const char *key, bool success);
 
   // Function called when a network info is received.
   bool (*network_info_fn)(bm_common_network_info_t *network_info);
@@ -131,25 +132,20 @@ bm_serial_error_e bm_serial_dfu_send_start(bm_serial_dfu_start_t *dfu_start);
 bm_serial_error_e bm_serial_dfu_send_chunk(uint32_t offset, size_t length, uint8_t *data);
 bm_serial_error_e bm_serial_dfu_send_finish(uint64_t node_id, bool success, uint32_t status);
 
-bm_serial_error_e bm_serial_cfg_get(uint64_t node_id, bm_common_config_partition_e partition,
+bm_serial_error_e bm_serial_cfg_get(uint64_t node_id, BmConfigPartition partition,
                                     size_t key_len, const char *key);
-bm_serial_error_e bm_serial_cfg_set(uint64_t node_id, bm_common_config_partition_e partition,
+bm_serial_error_e bm_serial_cfg_set(uint64_t node_id, BmConfigPartition partition,
                                     size_t key_len, const char *key, size_t value_size,
                                     void *val);
-bm_serial_error_e bm_serial_cfg_value(uint64_t node_id, bm_common_config_partition_e partition,
+bm_serial_error_e bm_serial_cfg_value(uint64_t node_id, BmConfigPartition partition,
                                       uint32_t data_length, void *data);
-bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id,
-                                       bm_common_config_partition_e partition);
-bm_serial_error_e bm_serial_cfg_status_request(uint64_t node_id,
-                                               bm_common_config_partition_e partition);
-bm_serial_error_e bm_serial_cfg_status_response(uint64_t node_id,
-                                                bm_common_config_partition_e partition,
+bm_serial_error_e bm_serial_cfg_commit(uint64_t node_id, BmConfigPartition partition);
+bm_serial_error_e bm_serial_cfg_status_request(uint64_t node_id, BmConfigPartition partition);
+bm_serial_error_e bm_serial_cfg_status_response(uint64_t node_id, BmConfigPartition partition,
                                                 bool commited, uint8_t num_keys, void *keys);
-bm_serial_error_e bm_serial_cfg_delete_request(uint64_t node_id,
-                                               bm_common_config_partition_e partition,
+bm_serial_error_e bm_serial_cfg_delete_request(uint64_t node_id, BmConfigPartition partition,
                                                size_t key_len, const char *key);
-bm_serial_error_e bm_serial_cfg_delete_response(uint64_t node_id,
-                                                bm_common_config_partition_e partition,
+bm_serial_error_e bm_serial_cfg_delete_response(uint64_t node_id, BmConfigPartition partition,
                                                 size_t key_len, const char *key, bool success);
 
 bm_serial_error_e bm_serial_send_info_request(uint64_t node_id);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,9 @@ target_include_directories(bm_serial_tests
     PRIVATE
     ${SRC_DIR}
     ${TEST_DIR}
-    ${BM_COMMON_MESSAGES_INCLUDES}
+    ${bmcore_SOURCE_DIR}/common
+    ${bmcore_SOURCE_DIR}/bcmp
+    ${bmcore_SOURCE_DIR}/third_party/tinycbor/src
 )
 
 target_sources(bm_serial_tests

--- a/test/bm_serial_ut.cpp
+++ b/test/bm_serial_ut.cpp
@@ -1,5 +1,6 @@
-#include "gtest/gtest.h"
 #include "bm_serial.h"
+#include "messages.h"
+#include "gtest/gtest.h"
 
 #include <string.h>
 
@@ -10,24 +11,24 @@ static uint32_t serial_tx_buff_len;
 
 // The fixture for testing class Foo.
 class NCPTest : public ::testing::Test {
- protected:
+protected:
   // You can remove any or all of the following functions if its body
   // is empty.
 
   NCPTest() {
-     // You can do set-up work for each test here.
+    // You can do set-up work for each test here.
   }
 
   ~NCPTest() override {
-     // You can do clean-up work that doesn't throw exceptions here.
+    // You can do clean-up work that doesn't throw exceptions here.
   }
 
   // If the constructor and destructor are not enough for setting up
   // and cleaning up each test, you can define the following methods:
 
   void SetUp() override {
-     // Code here will be called immediately after the constructor (right
-     // before each test).
+    // Code here will be called immediately after the constructor (right
+    // before each test).
 
     // Clear local callbacks
     memset(&_callbacks, 0, sizeof(_callbacks));
@@ -41,8 +42,8 @@ class NCPTest : public ::testing::Test {
   }
 
   void TearDown() override {
-     // Code here will be called immediately after each test (right
-     // before the destructor).
+    // Code here will be called immediately after each test (right
+    // before the destructor).
   }
 
   // Objects declared here can be used by all tests in the test suite for Foo.
@@ -50,7 +51,7 @@ class NCPTest : public ::testing::Test {
 
 // Fake serial_tx function just copies data into buffer so we can process it
 bool fake_tx_fn(const uint8_t *buff, size_t len) {
-  if(len >= sizeof(serial_tx_buff)) {
+  if (len >= sizeof(serial_tx_buff)) {
     serial_tx_buff_len = 0;
     return false;
   }
@@ -68,7 +69,7 @@ TEST_F(NCPTest, ErrorTests) {
 
   uint8_t buff[128];
   // Try to send a message that's too big
-  EXPECT_EQ(bm_serial_tx(BM_SERIAL_DEBUG, buff, 1024*10), BM_SERIAL_OVERFLOW);
+  EXPECT_EQ(bm_serial_tx(BM_SERIAL_DEBUG, buff, 1024 * 10), BM_SERIAL_OVERFLOW);
 
   // Try to send message without a tx callback
   EXPECT_EQ(bm_serial_tx(BM_SERIAL_DEBUG, buff, sizeof(buff)), BM_SERIAL_MISSING_CALLBACK);
@@ -104,12 +105,14 @@ TEST_F(NCPTest, SubUnsubTests) {
 
   fake_sub_called = false;
   EXPECT_EQ(bm_serial_sub("fake_sub_topic", sizeof("fake_sub_topic")), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_sub_called);
 
   fake_unsub_called = false;
   EXPECT_EQ(bm_serial_unsub("fake_unsub_topic", sizeof("fake_unsub_topic")), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_unsub_called);
 }
 
@@ -136,7 +139,8 @@ TEST_F(NCPTest, RTCTest) {
   rtc_time.second = 10;
   rtc_time.us = 123456;
   EXPECT_EQ(bm_serial_set_rtc(&rtc_time), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_rtc_called);
 }
 
@@ -149,7 +153,7 @@ bool dfu_start_fn(bm_serial_dfu_start_t *start) {
 }
 
 static bool fake_dfu_chunk_called;
-bool dfu_chunk_fun(uint32_t offset, size_t length, uint8_t * data) {
+bool dfu_chunk_fun(uint32_t offset, size_t length, uint8_t *data) {
   (void)offset;
   (void)length;
   (void)data;
@@ -161,8 +165,8 @@ bool dfu_chunk_fun(uint32_t offset, size_t length, uint8_t * data) {
 static bool fake_dfu_finish_called;
 bool dfu_finish_fn(uint64_t node_id, bool success, uint32_t err) {
   (void)node_id;
-  (void) success;
-  (void) err;
+  (void)success;
+  (void)err;
 
   fake_dfu_finish_called = true;
   return true;
@@ -177,110 +181,115 @@ TEST_F(NCPTest, DFUTest) {
 
   fake_dfu_start_called = false;
   bm_serial_dfu_start_t start = {
-   .node_id = 0xdeaddeaddeaddead,
-   .image_size = 2048,
-   .chunk_size = 512,
-   .crc16 = 0xbeef,
-   .major_ver = 2,
-   .minor_ver = 1,
-   .filter_key = 0,
-   .gitSHA = 0x12345678,
+      .node_id = 0xdeaddeaddeaddead,
+      .image_size = 2048,
+      .chunk_size = 512,
+      .crc16 = 0xbeef,
+      .major_ver = 2,
+      .minor_ver = 1,
+      .filter_key = 0,
+      .gitSHA = 0x12345678,
   };
   EXPECT_EQ(bm_serial_dfu_send_start(&start), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_dfu_start_called);
 
   fake_dfu_chunk_called = false;
   uint8_t buf = 1;
   EXPECT_EQ(bm_serial_dfu_send_chunk(0, sizeof(buf), &buf), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_dfu_chunk_called);
 
   fake_dfu_chunk_called = false;
   EXPECT_EQ(bm_serial_dfu_send_chunk(0, 0, NULL), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_dfu_chunk_called);
 
   fake_dfu_finish_called = false;
   EXPECT_EQ(bm_serial_dfu_send_finish(0xdeadbaaddaadbead, 1, 0), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_dfu_finish_called);
 }
 
 static bool fake_cfg_get_fn_called;
-static bool fake_cfg_get_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len, const char* key) {
-  (void) node_id;
-  (void) partition;
-  (void) key_len;
-  (void) key;
+static bool fake_cfg_get_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len,
+                            const char *key) {
+  (void)node_id;
+  (void)partition;
+  (void)key_len;
+  (void)key;
   fake_cfg_get_fn_called = true;
   return true;
 }
 static bool fake_cfg_set_fn_called;
-static bool fake_cfg_set_fn(uint64_t node_id, BmConfigPartition partition,
-  size_t key_len, const char* key, size_t value_size, void * val) {
-  (void) node_id;
-  (void) partition;
-  (void) key_len;
-  (void) key;
-  (void) value_size;
-  (void) val;
+static bool fake_cfg_set_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len,
+                            const char *key, size_t value_size, void *val) {
+  (void)node_id;
+  (void)partition;
+  (void)key_len;
+  (void)key;
+  (void)value_size;
+  (void)val;
   fake_cfg_set_fn_called = true;
   return true;
-
 }
 static bool fake_cfg_value_fn_called;
-static bool fake_cfg_value_fn(uint64_t node_id, BmConfigPartition partition, uint32_t data_length, void* data) {
-  (void) node_id;
-  (void) partition;
-  (void) data_length;
-  (void) data;
+static bool fake_cfg_value_fn(uint64_t node_id, BmConfigPartition partition,
+                              uint32_t data_length, void *data) {
+  (void)node_id;
+  (void)partition;
+  (void)data_length;
+  (void)data;
   fake_cfg_value_fn_called = true;
   return true;
-
 }
 static bool fake_cfg_commit_fn_called;
 static bool fake_cfg_commit_fn(uint64_t node_id, BmConfigPartition partition) {
-  (void) node_id;
-  (void) partition;
+  (void)node_id;
+  (void)partition;
   fake_cfg_commit_fn_called = true;
   return true;
-
 }
 static bool fake_cfg_status_request_fn_called;
 static bool fake_cfg_status_request_fn(uint64_t node_id, BmConfigPartition partition) {
-  (void) node_id;
-  (void) partition;
+  (void)node_id;
+  (void)partition;
   fake_cfg_status_request_fn_called = true;
   return true;
-
 }
 static bool fake_cfg_status_response_fn_called;
-static bool fake_cfg_status_response_fn(uint64_t node_id, BmConfigPartition partition, bool commited, uint8_t num_keys, void* keys) {
-  (void) node_id;
-  (void) partition;
-  (void) commited;
-  (void) num_keys;
-  (void) keys;
+static bool fake_cfg_status_response_fn(uint64_t node_id, BmConfigPartition partition,
+                                        bool commited, uint8_t num_keys, void *keys) {
+  (void)node_id;
+  (void)partition;
+  (void)commited;
+  (void)num_keys;
+  (void)keys;
   fake_cfg_status_response_fn_called = true;
   return true;
 }
 static bool fake_cfg_key_del_request_fn_called;
-static bool fake_cfg_key_del_request_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len, const char * key) {
-  (void) node_id;
-  (void) partition;
-  (void) key_len;
-  (void) key;
+static bool fake_cfg_key_del_request_fn(uint64_t node_id, BmConfigPartition partition,
+                                        size_t key_len, const char *key) {
+  (void)node_id;
+  (void)partition;
+  (void)key_len;
+  (void)key;
   fake_cfg_key_del_request_fn_called = true;
   return true;
 }
 static bool fake_cfg_key_del_response_fn_called;
-static bool fake_cfg_key_del_response_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len, const char * key, bool success) {
-  (void) node_id;
-  (void) partition;
-  (void) key_len;
-  (void) key;
-  (void) success;
+static bool fake_cfg_key_del_response_fn(uint64_t node_id, BmConfigPartition partition,
+                                         size_t key_len, const char *key, bool success) {
+  (void)node_id;
+  (void)partition;
+  (void)key_len;
+  (void)key;
+  (void)success;
   fake_cfg_key_del_response_fn_called = true;
   return true;
 }
@@ -296,7 +305,7 @@ TEST_F(NCPTest, ConfigTest) {
   _callbacks.cfg_key_del_request_fn = fake_cfg_key_del_request_fn;
   _callbacks.cfg_key_del_response_fn = fake_cfg_key_del_response_fn;
   bm_serial_set_callbacks(&_callbacks);
-  fake_cfg_get_fn_called  = false;
+  fake_cfg_get_fn_called = false;
   fake_cfg_set_fn_called = false;
   fake_cfg_value_fn_called = false;
   fake_cfg_commit_fn_called = false;
@@ -305,56 +314,79 @@ TEST_F(NCPTest, ConfigTest) {
   fake_cfg_key_del_request_fn_called = false;
   fake_cfg_key_del_response_fn_called = false;
 
-  EXPECT_EQ(bm_serial_cfg_get(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(
+      bm_serial_cfg_get(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),
+      BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_get_fn_called);
 
   uint32_t test = 42;
-  EXPECT_EQ(bm_serial_cfg_set(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo", sizeof(uint32_t), &test),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_set(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo",
+                              sizeof(uint32_t), &test),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_set_fn_called);
 
-  EXPECT_EQ(bm_serial_cfg_commit(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_commit(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_commit_fn_called);
 
   uint32_t result = 10;
-  EXPECT_EQ(bm_serial_cfg_value(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof(result), &result),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(
+      bm_serial_cfg_value(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof(result), &result),
+      BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_value_fn_called);
 
-  EXPECT_EQ(bm_serial_cfg_status_request(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_status_request(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_status_request_fn_called);
 
   const char hello[] = "hello_world";
   uint32_t len = sizeof(BmConfigStatusKeyData) + sizeof(hello);
-  uint8_t * keybuffer = (uint8_t*) malloc(len);
+  uint8_t *keybuffer = (uint8_t *)malloc(len);
   BmConfigStatusKeyData *key = (BmConfigStatusKeyData *)keybuffer;
   key->key_length = sizeof(hello);
   memcpy(key->key, hello, sizeof(hello));
 
-  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, true, 1, keybuffer),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, true, 1,
+                                          keybuffer),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_status_response_fn_called);
   free(keybuffer);
 
-  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, true, 0, NULL),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(
+      bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, true, 0, NULL),
+      BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
 
-  EXPECT_EQ(bm_serial_cfg_delete_request(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_delete_request(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM,
+                                         sizeof("foo"), "foo"),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_key_del_request_fn_called);
 
-  EXPECT_EQ(bm_serial_cfg_delete_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo", true),BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_delete_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM,
+                                          sizeof("foo"), "foo", true),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_key_del_response_fn_called);
-
 }
 
 static bool fake_network_info_fn_called;
-static bool fake_network_info_fn(BmNetworkInfo* network_info) {
-  (void) network_info;
+static bool fake_network_info_fn(BmNetworkInfo *network_info) {
+  (void)network_info;
   fake_network_info_fn_called = true;
   return true;
 }
@@ -366,36 +398,41 @@ TEST_F(NCPTest, NetworkInfoTest) {
   fake_network_info_fn_called = false;
 
   BmConfigCrc config_crc = {
-    .partition = BM_CFG_PARTITION_SYSTEM,
-    .crc32 = 1234,
+      .partition = BM_CFG_PARTITION_SYSTEM,
+      .crc32 = 1234,
   };
 
   BmFwVersion fw_info = {
-    .major = 1,
-    .minor = 2,
-    .revision = 3,
-    .gitSHA = 1234,
+      .major = 1,
+      .minor = 2,
+      .revision = 3,
+      .gitSHA = 1234,
   };
 
   uint64_t node_list[] = {12345678};
   uint16_t num_nodes = 1;
 
   // {"Hello":"World"}
-  uint8_t cbor_map[] = {0xA1,0x65,0x48,0x65,0x6C,0x6C,0x6F,0x65,0x57,0x6F,0x72,0x6C,0x64};
+  uint8_t cbor_map[] = {0xA1, 0x65, 0x48, 0x65, 0x6C, 0x6C, 0x6F,
+                        0x65, 0x57, 0x6F, 0x72, 0x6C, 0x64};
 
-  EXPECT_EQ(bm_serial_send_network_info((uint32_t)1234, &config_crc, &fw_info, num_nodes, node_list, sizeof(cbor_map), cbor_map), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_send_network_info((uint32_t)1234, &config_crc, &fw_info, num_nodes,
+                                        node_list, sizeof(cbor_map), cbor_map),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(fake_network_info_fn_called);
 }
 
 static bool reboot_info_fn_called;
-static bool fake_reboot_info_fn(uint64_t node_id, uint32_t reboot_reason, uint32_t gitSHA, uint32_t reboot_count, uint32_t pc, uint32_t lr) {
-  (void) node_id;
-  (void) reboot_reason;
-  (void) gitSHA;
-  (void) reboot_count;
-  (void) pc;
-  (void) lr;
+static bool fake_reboot_info_fn(uint64_t node_id, uint32_t reboot_reason, uint32_t gitSHA,
+                                uint32_t reboot_count, uint32_t pc, uint32_t lr) {
+  (void)node_id;
+  (void)reboot_reason;
+  (void)gitSHA;
+  (void)reboot_count;
+  (void)pc;
+  (void)lr;
   reboot_info_fn_called = true;
   return true;
 }
@@ -406,7 +443,9 @@ TEST_F(NCPTest, RebootInfoTest) {
   bm_serial_set_callbacks(&_callbacks);
   reboot_info_fn_called = false;
 
-  EXPECT_EQ(bm_serial_send_reboot_info(0xdadb0dc0ffee, 3, 0xbaddd00d, 1, 0x1234567, 0xfffffff), BM_SERIAL_OK);
-  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_send_reboot_info(0xdadb0dc0ffee, 3, 0xbaddd00d, 1, 0x1234567, 0xfffffff),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
   EXPECT_TRUE(reboot_info_fn_called);
 }

--- a/test/bm_serial_ut.cpp
+++ b/test/bm_serial_ut.cpp
@@ -208,7 +208,7 @@ TEST_F(NCPTest, DFUTest) {
 }
 
 static bool fake_cfg_get_fn_called;
-static bool fake_cfg_get_fn(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len, const char* key) {
+static bool fake_cfg_get_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len, const char* key) {
   (void) node_id;
   (void) partition;
   (void) key_len;
@@ -217,7 +217,7 @@ static bool fake_cfg_get_fn(uint64_t node_id, bm_common_config_partition_e parti
   return true;
 }
 static bool fake_cfg_set_fn_called;
-static bool fake_cfg_set_fn(uint64_t node_id, bm_common_config_partition_e partition,
+static bool fake_cfg_set_fn(uint64_t node_id, BmConfigPartition partition,
   size_t key_len, const char* key, size_t value_size, void * val) {
   (void) node_id;
   (void) partition;
@@ -230,7 +230,7 @@ static bool fake_cfg_set_fn(uint64_t node_id, bm_common_config_partition_e parti
 
 }
 static bool fake_cfg_value_fn_called;
-static bool fake_cfg_value_fn(uint64_t node_id, bm_common_config_partition_e partition, uint32_t data_length, void* data) {
+static bool fake_cfg_value_fn(uint64_t node_id, BmConfigPartition partition, uint32_t data_length, void* data) {
   (void) node_id;
   (void) partition;
   (void) data_length;
@@ -240,7 +240,7 @@ static bool fake_cfg_value_fn(uint64_t node_id, bm_common_config_partition_e par
 
 }
 static bool fake_cfg_commit_fn_called;
-static bool fake_cfg_commit_fn(uint64_t node_id, bm_common_config_partition_e partition) {
+static bool fake_cfg_commit_fn(uint64_t node_id, BmConfigPartition partition) {
   (void) node_id;
   (void) partition;
   fake_cfg_commit_fn_called = true;
@@ -248,7 +248,7 @@ static bool fake_cfg_commit_fn(uint64_t node_id, bm_common_config_partition_e pa
 
 }
 static bool fake_cfg_status_request_fn_called;
-static bool fake_cfg_status_request_fn(uint64_t node_id, bm_common_config_partition_e partition) {
+static bool fake_cfg_status_request_fn(uint64_t node_id, BmConfigPartition partition) {
   (void) node_id;
   (void) partition;
   fake_cfg_status_request_fn_called = true;
@@ -256,7 +256,7 @@ static bool fake_cfg_status_request_fn(uint64_t node_id, bm_common_config_partit
 
 }
 static bool fake_cfg_status_response_fn_called;
-static bool fake_cfg_status_response_fn(uint64_t node_id, bm_common_config_partition_e partition, bool commited, uint8_t num_keys, void* keys) {
+static bool fake_cfg_status_response_fn(uint64_t node_id, BmConfigPartition partition, bool commited, uint8_t num_keys, void* keys) {
   (void) node_id;
   (void) partition;
   (void) commited;
@@ -266,7 +266,7 @@ static bool fake_cfg_status_response_fn(uint64_t node_id, bm_common_config_parti
   return true;
 }
 static bool fake_cfg_key_del_request_fn_called;
-static bool fake_cfg_key_del_request_fn(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len, const char * key) {
+static bool fake_cfg_key_del_request_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len, const char * key) {
   (void) node_id;
   (void) partition;
   (void) key_len;
@@ -275,7 +275,7 @@ static bool fake_cfg_key_del_request_fn(uint64_t node_id, bm_common_config_parti
   return true;
 }
 static bool fake_cfg_key_del_response_fn_called;
-static bool fake_cfg_key_del_response_fn(uint64_t node_id, bm_common_config_partition_e partition, size_t key_len, const char * key, bool success) {
+static bool fake_cfg_key_del_response_fn(uint64_t node_id, BmConfigPartition partition, size_t key_len, const char * key, bool success) {
   (void) node_id;
   (void) partition;
   (void) key_len;
@@ -305,25 +305,25 @@ TEST_F(NCPTest, ConfigTest) {
   fake_cfg_key_del_request_fn_called = false;
   fake_cfg_key_del_response_fn_called = false;
 
-  EXPECT_EQ(bm_serial_cfg_get(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_get(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_get_fn_called);
 
   uint32_t test = 42;
-  EXPECT_EQ(bm_serial_cfg_set(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo", sizeof(uint32_t), &test),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_set(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo", sizeof(uint32_t), &test),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_set_fn_called);
 
-  EXPECT_EQ(bm_serial_cfg_commit(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_commit(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_commit_fn_called);
 
   uint32_t result = 10;
-  EXPECT_EQ(bm_serial_cfg_value(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, sizeof(result), &result),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_value(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof(result), &result),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_value_fn_called);
 
-  EXPECT_EQ(bm_serial_cfg_status_request(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_status_request(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_status_request_fn_called);
 
@@ -334,19 +334,19 @@ TEST_F(NCPTest, ConfigTest) {
   key->key_length = sizeof(hello);
   memcpy(key->key, hello, sizeof(hello));
 
-  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, true, 1, keybuffer),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, true, 1, keybuffer),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_status_response_fn_called);
   free(keybuffer);
 
-  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, true, 0, NULL),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_status_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, true, 0, NULL),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
 
-  EXPECT_EQ(bm_serial_cfg_delete_request(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_delete_request(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo"),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_key_del_request_fn_called);
 
-  EXPECT_EQ(bm_serial_cfg_delete_response(0xdeadbadc0ffeedad, BM_COMMON_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo", true),BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_cfg_delete_response(0xdeadbadc0ffeedad, BM_CFG_PARTITION_SYSTEM, sizeof("foo"), "foo", true),BM_SERIAL_OK);
   EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len), BM_SERIAL_OK);
   EXPECT_TRUE(fake_cfg_key_del_response_fn_called);
 
@@ -366,7 +366,7 @@ TEST_F(NCPTest, NetworkInfoTest) {
   fake_network_info_fn_called = false;
 
   bm_common_config_crc_t config_crc = {
-    .partition = BM_COMMON_CFG_PARTITION_SYSTEM,
+    .partition = BM_CFG_PARTITION_SYSTEM,
     .crc32 = 1234,
   };
 

--- a/test/bm_serial_ut.cpp
+++ b/test/bm_serial_ut.cpp
@@ -328,9 +328,9 @@ TEST_F(NCPTest, ConfigTest) {
   EXPECT_TRUE(fake_cfg_status_request_fn_called);
 
   const char hello[] = "hello_world";
-  uint32_t len = sizeof(bm_common_config_status_key_data_t) + sizeof(hello);
+  uint32_t len = sizeof(BmConfigStatusKeyData) + sizeof(hello);
   uint8_t * keybuffer = (uint8_t*) malloc(len);
-  bm_common_config_status_key_data_t *key = (bm_common_config_status_key_data_t *)keybuffer;
+  BmConfigStatusKeyData *key = (BmConfigStatusKeyData *)keybuffer;
   key->key_length = sizeof(hello);
   memcpy(key->key, hello, sizeof(hello));
 
@@ -353,7 +353,7 @@ TEST_F(NCPTest, ConfigTest) {
 }
 
 static bool fake_network_info_fn_called;
-static bool fake_network_info_fn(bm_common_network_info_t* network_info) {
+static bool fake_network_info_fn(BmNetworkInfo* network_info) {
   (void) network_info;
   fake_network_info_fn_called = true;
   return true;
@@ -365,12 +365,12 @@ TEST_F(NCPTest, NetworkInfoTest) {
   bm_serial_set_callbacks(&_callbacks);
   fake_network_info_fn_called = false;
 
-  bm_common_config_crc_t config_crc = {
+  BmConfigCrc config_crc = {
     .partition = BM_CFG_PARTITION_SYSTEM,
     .crc32 = 1234,
   };
 
-  bm_common_fw_version_t fw_info = {
+  BmFwVersion fw_info = {
     .major = 1,
     .minor = 2,
     .revision = 3,


### PR DESCRIPTION
This gets rid of bm_common_messages... don't know if this is desireable, but, there was a lot of discrepancies be struct names in `bm_common_messages` and `bm_core` in regards to the the `configuration` module in `bm_core`. Let me know your thoughts.