### PR TITLE
Added metrics request and reply functionality for CLI command

### DIFF
--- a/bm_serial.c
+++ b/bm_serial.c
@@ -1071,23 +1071,11 @@ bm_serial_error_e bm_serial_send_power_stats_reply(bm_serial_power_status_reply_
 }
 
 bm_serial_error_e bm_serial_send_metrics_request(uint64_t node_id) {
-  bm_serial_error_e rval = BM_SERIAL_OK;
-  do {
-    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_metrics_request_t);
-    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_METRICS_REQ, 0, message_len);
-    if (!packet) {
-      rval = BM_SERIAL_OUT_OF_MEMORY;
-      break;
-    }
-    bm_serial_metrics_request_t *req_msg = (bm_serial_metrics_request_t *)packet->payload;
-    req_msg->target_node_id = node_id;
-    packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
-    if (!_callbacks.tx_fn((uint8_t *)packet, message_len, BM_SERIAL_METRICS_REQ)) {
-      rval = BM_SERIAL_TX_ERR;
-      break;
-    }
-  } while (0);
-  return rval;
+  bm_serial_metrics_request_t request = {
+      .target_node_id = node_id,
+  };
+  return serialize_send_message(BM_SERIAL_METRICS_REQ, 0, &request,
+                                sizeof(bm_serial_metrics_request_t));
 }
 
 bm_serial_error_e bm_serial_send_metrics_reply(uint64_t node_id, const char *text,

--- a/bm_serial.c
+++ b/bm_serial.c
@@ -1070,6 +1070,49 @@ bm_serial_error_e bm_serial_send_power_stats_reply(bm_serial_power_status_reply_
   return BM_SERIAL_OK;
 }
 
+bm_serial_error_e bm_serial_send_metrics_request(uint64_t node_id) {
+  bm_serial_error_e rval = BM_SERIAL_OK;
+  do {
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_metrics_request_t);
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_METRICS_REQ, 0, message_len);
+    if (!packet) {
+      rval = BM_SERIAL_OUT_OF_MEMORY;
+      break;
+    }
+    bm_serial_metrics_request_t *req_msg = (bm_serial_metrics_request_t *)packet->payload;
+    req_msg->target_node_id = node_id;
+    packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
+    if (!_callbacks.tx_fn((uint8_t *)packet, message_len, BM_SERIAL_METRICS_REQ)) {
+      rval = BM_SERIAL_TX_ERR;
+      break;
+    }
+  } while (0);
+  return rval;
+}
+
+bm_serial_error_e bm_serial_send_metrics_reply(uint64_t node_id, const char *text,
+                                               uint16_t text_len) {
+  bm_serial_error_e rval = BM_SERIAL_OK;
+  do {
+    uint16_t message_len = sizeof(bm_serial_packet_t) + sizeof(bm_serial_metrics_reply_t) + text_len;
+    bm_serial_packet_t *packet = _bm_serial_get_packet(BM_SERIAL_METRICS_REPLY, 0, message_len);
+    if (!packet) {
+      rval = BM_SERIAL_OUT_OF_MEMORY;
+      break;
+    }
+    bm_serial_metrics_reply_t *reply_msg = (bm_serial_metrics_reply_t *)packet->payload;
+    reply_msg->node_id = node_id;
+    reply_msg->text_len = text_len;
+    memcpy(reply_msg->text, text, text_len);
+    packet->crc16 = bm_serial_crc16_ccitt(0, (uint8_t *)packet, message_len);
+    if (!_callbacks.tx_fn((uint8_t *)packet, message_len, BM_SERIAL_METRICS_REPLY)) {
+      rval = BM_SERIAL_TX_ERR;
+      break;
+    }
+  } while (0);
+  return rval;
+}
+
 bm_serial_error_e bm_serial_send_usv_metrics(bm_serial_usv_metrics_t metrics) {
   return serialize_send_message(BM_SERIAL_USV_METRICS, 0, &metrics,
                                 sizeof(bm_serial_usv_metrics_t));
@@ -1390,6 +1433,20 @@ bm_serial_error_e bm_serial_process_packet(bm_serial_packet_t *packet, size_t le
         bm_serial_power_status_reply_data_t *reply =
             (bm_serial_power_status_reply_data_t *)packet->payload;
         _callbacks.power_stats_reply_fn(*reply);
+      }
+      break;
+    }
+    case BM_SERIAL_METRICS_REQ: {
+      if (_callbacks.metrics_request_fn) {
+        bm_serial_metrics_request_t *req = (bm_serial_metrics_request_t *)packet->payload;
+        _callbacks.metrics_request_fn(req->target_node_id);
+      }
+      break;
+    }
+    case BM_SERIAL_METRICS_REPLY: {
+      if (_callbacks.metrics_reply_fn) {
+        bm_serial_metrics_reply_t *reply = (bm_serial_metrics_reply_t *)packet->payload;
+        _callbacks.metrics_reply_fn(reply->node_id, reply->text, reply->text_len);
       }
       break;
     }

--- a/bm_serial.h
+++ b/bm_serial.h
@@ -122,10 +122,10 @@ typedef struct {
   bool (*power_stats_request_fn)(void);
 
   bool (*power_stats_reply_fn)(bm_serial_power_status_reply_data_t stats);
-  
+
   // Function called when a metrics request is received 
   bool (*metrics_request_fn)(uint64_t node_id);
-  
+
   // Function called when a metrics reply is received
   bool (*metrics_reply_fn)(uint64_t node_id, const char *text, uint16_t text_len);
 

--- a/bm_serial.h
+++ b/bm_serial.h
@@ -122,6 +122,12 @@ typedef struct {
   bool (*power_stats_request_fn)(void);
 
   bool (*power_stats_reply_fn)(bm_serial_power_status_reply_data_t stats);
+  
+  // Function called when a metrics request is received 
+  bool (*metrics_request_fn)(uint64_t node_id);
+  
+  // Function called when a metrics reply is received
+  bool (*metrics_reply_fn)(uint64_t node_id, const char *text, uint16_t text_len);
 
   bool (*usv_metrics_fn)(bm_serial_usv_metrics_t metrics);
 } bm_serial_callbacks_t;
@@ -203,6 +209,10 @@ bm_serial_error_e bm_serial_send_baud_rate_reply(void);
 
 bm_serial_error_e bm_serial_send_power_stats_request(void);
 bm_serial_error_e bm_serial_send_power_stats_reply(bm_serial_power_status_reply_data_t reply);
+
+bm_serial_error_e bm_serial_send_metrics_request(uint64_t node_id);
+bm_serial_error_e bm_serial_send_metrics_reply(uint64_t node_id, const char *text,
+                                               uint16_t text_len);
 
 bm_serial_error_e bm_serial_send_usv_metrics(bm_serial_usv_metrics_t metrics);
 

--- a/bm_serial_messages.h
+++ b/bm_serial_messages.h
@@ -47,6 +47,9 @@ typedef enum {
   BM_SERIAL_POWER_STATUS_REQ = 0x74,
   BM_SERIAL_POWER_STATUS_REPLY = 0x75,
 
+  BM_SERIAL_METRICS_REQ = 0x76,
+  BM_SERIAL_METRICS_REPLY = 0x77,
+
   BM_SERIAL_USV_METRICS = 0x80,
 } bm_serial_message_t;
 
@@ -247,6 +250,20 @@ typedef struct {
   // Time the network will be off
   uint32_t remaining_off_ms;
 } __attribute__((packed)) bm_serial_power_status_reply_data_t;
+
+typedef struct {
+  // Node ID of the target node for which the request is being made. (Zeroed = all nodes)
+  uint64_t target_node_id;
+} __attribute__((packed)) bm_serial_metrics_request_t;
+
+typedef struct {
+  // Node ID of the node the metrics came from
+  uint64_t node_id;
+  // Length of the human-readable metrics text
+  uint16_t text_len;
+  // Human-readable metrics text
+  char text[0];
+} __attribute__((packed)) bm_serial_metrics_reply_t;
 
 typedef struct {
   bool has_imu;

--- a/test/bm_serial_ut.cpp
+++ b/test/bm_serial_ut.cpp
@@ -490,3 +490,67 @@ TEST_F(NCPTest, USVMetrics) {
             BM_SERIAL_OK);
   EXPECT_TRUE(metrics_fn_called);
 }
+
+static bool metrics_request_fn_called = false;
+static uint64_t metrics_request_node_id = 0;
+
+static bool fake_metrics_request_fn(uint64_t node_id) {
+  metrics_request_node_id = node_id;
+  metrics_request_fn_called = true;
+  return true;
+}
+
+TEST_F(NCPTest, MetricsRequestTest) {
+  _callbacks.tx_fn = fake_tx_fn;
+  _callbacks.metrics_request_fn = fake_metrics_request_fn;
+  bm_serial_set_callbacks(&_callbacks);
+  metrics_request_fn_called = false;
+  metrics_request_node_id = 0;
+
+  EXPECT_EQ(bm_serial_send_metrics_request(0x0123456789abcdef), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
+  EXPECT_TRUE(metrics_request_fn_called);
+  EXPECT_EQ(metrics_request_node_id, 0x0123456789abcdefULL);
+}
+
+TEST_F(NCPTest, MetricsRequestAllNodesTest) {
+  _callbacks.tx_fn = fake_tx_fn;
+  _callbacks.metrics_request_fn = fake_metrics_request_fn;
+  bm_serial_set_callbacks(&_callbacks);
+  metrics_request_fn_called = false;
+  metrics_request_node_id = 0xFF;
+
+  EXPECT_EQ(bm_serial_send_metrics_request(0), BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
+  EXPECT_TRUE(metrics_request_fn_called);
+  EXPECT_EQ(metrics_request_node_id, 0ULL);
+}
+
+static bool metrics_reply_fn_called = false;
+static const char fake_metrics_text[] =
+    "{\"version\": 1, \"node_id\": 81985529216486895, \"data\": "
+    "{\"network_port_stats\": {\"num_ports\": 2, \"sqi_1\": 7, \"mse_1\": 32}}}";
+
+static bool fake_metrics_reply_fn(uint64_t node_id, const char *text, uint16_t text_len) {
+  EXPECT_EQ(node_id, 0x0123456789abcdefULL);
+  EXPECT_EQ(text_len, (uint16_t)strlen(fake_metrics_text));
+  EXPECT_EQ(memcmp(text, fake_metrics_text, text_len), 0);
+  metrics_reply_fn_called = true;
+  return true;
+}
+
+TEST_F(NCPTest, MetricsReplyTest) {
+  _callbacks.tx_fn = fake_tx_fn;
+  _callbacks.metrics_reply_fn = fake_metrics_reply_fn;
+  bm_serial_set_callbacks(&_callbacks);
+  metrics_reply_fn_called = false;
+
+  EXPECT_EQ(bm_serial_send_metrics_reply(0x0123456789abcdef, fake_metrics_text,
+                                         (uint16_t)strlen(fake_metrics_text)),
+            BM_SERIAL_OK);
+  EXPECT_EQ(bm_serial_process_packet((bm_serial_packet_t *)serial_tx_buff, serial_tx_buff_len),
+            BM_SERIAL_OK);
+  EXPECT_TRUE(metrics_reply_fn_called);
+}


### PR DESCRIPTION
## What changed?

Added a metrics request/reply message pair:
- New message types: `BM_SERIAL_METRICS_REQ` (0x76) and `BM_SERIAL_METRICS_REPLY` (0x77).
- Payloads: request carries a target `node_id` (0 = all nodes); reply carries `node_id` + a length-prefixed text field.
- Round-trip unit tests (single-node request, all-nodes request, reply payload).

## How does it make Bristlemouth better?

Gives the NCP link a dedicated channel to request node metrics on demand and return them.

## Where should reviewers focus?